### PR TITLE
Keycloak ngnix integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       - frontend
 
   frontend:
-    image: jerrypan44/portal-frontend:latest
+    image: hbpmip/portal-frontend:dev_5.2.1
     depends_on:
       - portalbackend
     ports:
@@ -131,8 +131,8 @@ services:
       VERSION: 'Frontend: dev_5.2.1, Backend: dev_v6.0.1, Exareme: dev_v12.1, Galaxy: v1.3.1'
       TRACKER_ID: UA-80660232-5
       GALAXY_URL: 'http://galaxy/nativeGalaxy'
-      KEYCLOAK_AUTH_URL: "http://88.197.53.10:8095/auth/"
-      KEYCLOAK_LOGIN_URL: "http://88.197.53.10:8095/auth/realms/MIP/protocol/openid-connect/auth"
+      KEYCLOAK_AUTH_URL: "http://127.0.0.1/auth/"
+      KEYCLOAK_LOGIN_URL: "http://127.0.0.1/auth/realms/MIP/protocol/openid-connect/auth"
     restart: on-failure
     networks:
       - frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,8 +98,8 @@ services:
       GALAXY_API_KEY: 'd14a4cc5eebf805eb2ff261374ed08a2'
       GALAXY_USERNAME: admin
       GALAXY_PASSWORD: password
-
-      KEYCLOAK_URL: '127.0.0.1'
+      
+      KEYCLOAK_URL: "127.0.0.1"
       AUTH_URI: 'https://127.0.0.1:8095/auth/realms/MIP/protocol/openid-connect/auth'
       USER_INFO_URI: 'https://127.0.0.1:8095/auth/realms/MIP/protocol/openid-connect/userinfo'
       TOKEN_URI: 'https://127.0.0.1:8095/auth/realms/MIP/protocol/openid-connect/token'
@@ -116,7 +116,7 @@ services:
       - frontend
 
   frontend:
-    image: hbpmip/portal-frontend:dev_5.2.1
+    image: jerrypan44/portal-frontend:latest
     depends_on:
       - portalbackend
     ports:
@@ -131,6 +131,8 @@ services:
       VERSION: 'Frontend: dev_5.2.1, Backend: dev_v6.0.1, Exareme: dev_v12.1, Galaxy: v1.3.1'
       TRACKER_ID: UA-80660232-5
       GALAXY_URL: 'http://galaxy/nativeGalaxy'
+      KEYCLOAK_AUTH_URL: "http://88.197.53.10:8095/auth/"
+      KEYCLOAK_LOGIN_URL: "http://88.197.53.10:8095/auth/realms/MIP/protocol/openid-connect/auth"
     restart: on-failure
     networks:
       - frontend
@@ -138,6 +140,8 @@ services:
 
   keycloak_db:
     image: postgres
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: keycloak
       POSTGRES_USER: keycloak
@@ -150,8 +154,9 @@ services:
 
   keycloak:
     image: jboss/keycloak
+    command:
+      -Djboss.http.port=8095 
     volumes:
-      - ./config/certs:/etc/x509/https
       - ./config/keycloak.json:/tmp/mip.json
       - ./tmp:/tmp
     environment:


### PR DESCRIPTION
Keep in mind that these additional steps need to be run to disable https in keycloak on the MIP realm

disable https in keycloak docker : 
 
docker exec -it {contaierID} bash 
cd /opt/jboss/keycloak/bin 
./kcadm.sh config credentials --server http://88.197.53.10:8095/auth --realm master --user admin 
./kcadm.sh update realms/MIP -s sslRequired=NONE

use password Pa55w0rd