### PR TITLE
Issue with gateway container does not auto restart

### DIFF
--- a/Federation/docker-compose.yml
+++ b/Federation/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - '8081:8081'
     depends_on:
       - portalbackend
+    restart: unless-stopped
 
   frontend:
     image: hbpmip/portal-frontend:${FRONTEND}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,7 @@ services:
       - '8081:8081'
     depends_on:
       - portalbackend
+    restart: unless-stopped
 
   frontend:
     image: hbpmip/portal-frontend:${FRONTEND}


### PR DESCRIPTION
The Gateway container configuration inside the docker-compose file is missing the parameter restart: unless-stopped causing the container to not restart alone (default value for restart is "no").